### PR TITLE
Better Error Handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ clean:
 	cd search-cluster && $(MAKE) clean
 	cd lambda_layer && $(MAKE) clean
 	cd gcp_lambda_layer && $(MAKE) clean
-	# cd cognito && $(MAKE) clean
+	cd lib && rm *.pyc
 
 trigger-inventory:
 	./bin/trigger_inventory.sh $(STACK_PREFIX)-$(env)-aws-inventory

--- a/aws-inventory/cloudformation/Inventory-Template.yaml
+++ b/aws-inventory/cloudformation/Inventory-Template.yaml
@@ -1628,7 +1628,7 @@ Resources:
                   [ "...", "${AWS::StackName}-ta-inventory", { "stat": "Sum", "period": 604800, "label": "ta-inventory" } ],
                   [ "...", "${AWS::StackName}-support-inventory", { "stat": "Sum", "period": 604800, "label": "support-inventory" } ],
                   [ "...", "${AWS::StackName}-cloudtrail-inventory", { "stat": "Sum", "period": 604800, "label": "cloudtrail-inventory" } ],
-                  [ "...", "${AWS::StackName}-cloudformation-inventory", { "stat": "Sum", "period": 604800, "label": "cloudtrail-inventory" } ],
+                  [ "...", "${AWS::StackName}-cloudformation-inventory", { "stat": "Sum", "period": 604800, "label": "cloudformation-inventory" } ],
                   [ "...", "${AWS::StackName}-cloudfront-inventory", { "stat": "Sum", "period": 604800, "label": "cloudfront-inventory" } ],
                   [ "...", "${AWS::StackName}-create-account-report", { "stat": "Sum", "period": 604800, "label": "create-account-report" } ],
                   [ "...", "${AWS::StackName}-create-foreign-account-report", { "stat": "Sum", "period": 604800, "label": "create-foreign-account-report" } ],

--- a/aws-inventory/lambda/inventory-ami.py
+++ b/aws-inventory/lambda/inventory-ami.py
@@ -43,7 +43,7 @@ def lambda_handler(event, context):
             ec2_client = target_account.get_client('ec2', region=r)
             process_instances(target_account, ec2_client, r)
 
-    except AssumeRoleError as e:
+    except AntiopeAssumeRoleError as e:
         logger.error("Unable to assume role into account {}({})".format(target_account.account_name, target_account.account_id))
         return()
     except ClientError as e:

--- a/aws-inventory/lambda/inventory-ami.py
+++ b/aws-inventory/lambda/inventory-ami.py
@@ -47,10 +47,10 @@ def lambda_handler(event, context):
         logger.error("Unable to assume role into account {}({})".format(target_account.account_name, target_account.account_id))
         return()
     except ClientError as e:
-        logger.error("AWS Error getting info for {}: {}".format(target_account.account_name, e))
-        return()
+        logger.critical("AWS Error getting info for {}: {}".format(target_account.account_name, e))
+        raise
     except Exception as e:
-        logger.error("{}\nMessage: {}\nContext: {}".format(e, message, vars(context)))
+        logger.critical("{}\nMessage: {}\nContext: {}".format(e, message, vars(context)))
         raise
 
 

--- a/aws-inventory/lambda/inventory-buckets.py
+++ b/aws-inventory/lambda/inventory-buckets.py
@@ -33,10 +33,10 @@ def lambda_handler(event, context):
         logger.error("Unable to assume role into account {}({})".format(target_account.account_name, target_account.account_id))
         return()
     except ClientError as e:
-        logger.error("AWS Error getting info for {}: {}".format(target_account.account_name, e))
-        return()
+        logger.critical("AWS Error getting info for {}: {}".format(target_account.account_name, e))
+        raise
     except Exception as e:
-        logger.error("{}\nMessage: {}\nContext: {}".format(e, message, vars(context)))
+        logger.critical("{}\nMessage: {}\nContext: {}".format(e, message, vars(context)))
         raise
 
 def discover_buckets(account):

--- a/aws-inventory/lambda/inventory-buckets.py
+++ b/aws-inventory/lambda/inventory-buckets.py
@@ -29,7 +29,7 @@ def lambda_handler(event, context):
         target_account = AWSAccount(message['account_id'])
         discover_buckets(target_account)
 
-    except AssumeRoleError as e:
+    except AntiopeAssumeRoleError as e:
         logger.error("Unable to assume role into account {}({})".format(target_account.account_name, target_account.account_id))
         return()
     except ClientError as e:

--- a/aws-inventory/lambda/inventory-cloudfront.py
+++ b/aws-inventory/lambda/inventory-cloudfront.py
@@ -54,10 +54,10 @@ def lambda_handler(event, context):
         logger.error("Unable to assume role into account {}({})".format(target_account.account_name, target_account.account_id))
         return()
     except ClientError as e:
-        logger.error("AWS Error getting info for {}: {}".format(target_account.account_name, e))
-        return()
+        logger.critical("AWS Error getting info for {}: {}".format(target_account.account_name, e))
+        raise
     except Exception as e:
-        logger.error("{}\nMessage: {}\nContext: {}".format(e, message, vars(context)))
+        logger.critical("{}\nMessage: {}\nContext: {}".format(e, message, vars(context)))
         raise
 
 

--- a/aws-inventory/lambda/inventory-cloudfront.py
+++ b/aws-inventory/lambda/inventory-cloudfront.py
@@ -50,7 +50,7 @@ def lambda_handler(event, context):
 
             save_resource_to_s3(RESOURCE_PATH, distribution['Id'], resource_item)
 
-    except AssumeRoleError as e:
+    except AntiopeAssumeRoleError as e:
         logger.error("Unable to assume role into account {}({})".format(target_account.account_name, target_account.account_id))
         return()
     except ClientError as e:

--- a/aws-inventory/lambda/inventory-cloudtrail.py
+++ b/aws-inventory/lambda/inventory-cloudtrail.py
@@ -30,7 +30,7 @@ def lambda_handler(event, context):
         for r in target_account.get_regions():
             discover_trails(target_account, r)
 
-    except AssumeRoleError as e:
+    except AntiopeAssumeRoleError as e:
         logger.error("Unable to assume role into account {}({})".format(target_account.account_name, target_account.account_id))
         return()
     except ClientError as e:

--- a/aws-inventory/lambda/inventory-cloudtrail.py
+++ b/aws-inventory/lambda/inventory-cloudtrail.py
@@ -34,10 +34,10 @@ def lambda_handler(event, context):
         logger.error("Unable to assume role into account {}({})".format(target_account.account_name, target_account.account_id))
         return()
     except ClientError as e:
-        logger.error("AWS Error getting info for {}: {}".format(target_account.account_name, e))
-        return()
+        logger.critical("AWS Error getting info for {}: {}".format(target_account.account_name, e))
+        raise
     except Exception as e:
-        logger.error("{}\nMessage: {}\nContext: {}".format(e, message, vars(context)))
+        logger.critical("{}\nMessage: {}\nContext: {}".format(e, message, vars(context)))
         raise
 
 def discover_trails(target_account, region):

--- a/aws-inventory/lambda/inventory-dx.py
+++ b/aws-inventory/lambda/inventory-dx.py
@@ -46,7 +46,7 @@ def lambda_handler(event, context):
         for gwid, resource_item in dx_gws.items():
             save_resource_to_s3(GW_PATH, resource_item['resourceId'], resource_item)
 
-    except AssumeRoleError as e:
+    except AntiopeAssumeRoleError as e:
         logger.error("Unable to assume role into account {}({})".format(target_account.account_name, target_account.account_id))
         return()
     except ClientError as e:

--- a/aws-inventory/lambda/inventory-dx.py
+++ b/aws-inventory/lambda/inventory-dx.py
@@ -50,12 +50,11 @@ def lambda_handler(event, context):
         logger.error("Unable to assume role into account {}({})".format(target_account.account_name, target_account.account_id))
         return()
     except ClientError as e:
-        logger.error("AWS Error getting info for {}: {}".format(target_account.account_name, e))
-        return()
+        logger.critical("AWS Error getting info for {}: {}".format(target_account.account_name, e))
+        raise
     except Exception as e:
         logger.critical("{}\nMessage: {}\nContext: {}".format(e, message, vars(context)))
         raise
-
 def discover_connections(target_account, region):
     '''Inventory all the Direct Connect Connections (ie, physical cross connects into AWS)'''
 

--- a/aws-inventory/lambda/inventory-ecr.py
+++ b/aws-inventory/lambda/inventory-ecr.py
@@ -30,7 +30,7 @@ def lambda_handler(event, context):
         for r in target_account.get_regions():
             discover_repos(target_account, r)
 
-    except AssumeRoleError as e:
+    except AntiopeAssumeRoleError as e:
         logger.error("Unable to assume role into account {}({})".format(target_account.account_name, target_account.account_id))
         return()
     except ClientError as e:

--- a/aws-inventory/lambda/inventory-ecr.py
+++ b/aws-inventory/lambda/inventory-ecr.py
@@ -34,10 +34,10 @@ def lambda_handler(event, context):
         logger.error("Unable to assume role into account {}({})".format(target_account.account_name, target_account.account_id))
         return()
     except ClientError as e:
-        logger.error("AWS Error getting info for {}: {}".format(target_account.account_name, e))
-        return()
+        logger.critical("AWS Error getting info for {}: {}".format(target_account.account_name, e))
+        raise
     except Exception as e:
-        logger.error("{}\nMessage: {}\nContext: {}".format(e, message, vars(context)))
+        logger.critical("{}\nMessage: {}\nContext: {}".format(e, message, vars(context)))
         raise
 
 def discover_repos(target_account, region):

--- a/aws-inventory/lambda/inventory-ecs.py
+++ b/aws-inventory/lambda/inventory-ecs.py
@@ -88,10 +88,10 @@ def lambda_handler(event, context):
         logger.error("Unable to assume role into account {}({})".format(target_account.account_name, target_account.account_id))
         return()
     except ClientError as e:
-        logger.error("AWS Error getting info for {}: {}".format(target_account.account_name, e))
-        return()
+        logger.critical("AWS Error getting info for {}: {}".format(target_account.account_name, e))
+        raise
     except Exception as e:
-        logger.error("{}\nMessage: {}\nContext: {}".format(e, message, vars(context)))
+        logger.critical("{}\nMessage: {}\nContext: {}".format(e, message, vars(context)))
         raise
 
 

--- a/aws-inventory/lambda/inventory-ecs.py
+++ b/aws-inventory/lambda/inventory-ecs.py
@@ -84,7 +84,7 @@ def lambda_handler(event, context):
                     save_resource_to_s3(TASK_RESOURCE_PATH, task_item['resourceId'], task_item)
 
 
-    except AssumeRoleError as e:
+    except AntiopeAssumeRoleError as e:
         logger.error("Unable to assume role into account {}({})".format(target_account.account_name, target_account.account_id))
         return()
     except ClientError as e:

--- a/aws-inventory/lambda/inventory-eni.py
+++ b/aws-inventory/lambda/inventory-eni.py
@@ -33,10 +33,10 @@ def lambda_handler(event, context):
         logger.error("Unable to assume role into account {}({})".format(target_account.account_name, target_account.account_id))
         return()
     except ClientError as e:
-        logger.error("AWS Error getting info for {}: {}".format(target_account.account_name, e))
-        return()
+        logger.critical("AWS Error getting info for {}: {}".format(target_account.account_name, e))
+        raise
     except Exception as e:
-        logger.error("{}\nMessage: {}\nContext: {}".format(e, message, vars(context)))
+        logger.critical("{}\nMessage: {}\nContext: {}".format(e, message, vars(context)))
         raise
 
 

--- a/aws-inventory/lambda/inventory-eni.py
+++ b/aws-inventory/lambda/inventory-eni.py
@@ -29,7 +29,7 @@ def lambda_handler(event, context):
         for r in target_account.get_regions():
             discover_enis(target_account, r)
 
-    except AssumeRoleError as e:
+    except AntiopeAssumeRoleError as e:
         logger.error("Unable to assume role into account {}({})".format(target_account.account_name, target_account.account_id))
         return()
     except ClientError as e:

--- a/aws-inventory/lambda/inventory-es.py
+++ b/aws-inventory/lambda/inventory-es.py
@@ -62,7 +62,7 @@ def lambda_handler(event, context):
                 object_name = "{}-{}-{}".format(domain_name, r, target_account.account_id)
                 save_resource_to_s3(RESOURCE_PATH, object_name, resource_item)
 
-    except AssumeRoleError as e:
+    except AntiopeAssumeRoleError as e:
         logger.error("Unable to assume role into account {}({})".format(target_account.account_name, target_account.account_id))
         return()
     except ClientError as e:

--- a/aws-inventory/lambda/inventory-es.py
+++ b/aws-inventory/lambda/inventory-es.py
@@ -66,10 +66,10 @@ def lambda_handler(event, context):
         logger.error("Unable to assume role into account {}({})".format(target_account.account_name, target_account.account_id))
         return()
     except ClientError as e:
-        logger.error("AWS Error getting info for {}: {}".format(target_account.account_name, e))
-        return()
+        logger.critical("AWS Error getting info for {}: {}".format(target_account.account_name, e))
+        raise
     except Exception as e:
-        logger.error("{}\nMessage: {}\nContext: {}".format(e, message, vars(context)))
+        logger.critical("{}\nMessage: {}\nContext: {}".format(e, message, vars(context)))
         raise
 
 

--- a/aws-inventory/lambda/inventory-health-report.py
+++ b/aws-inventory/lambda/inventory-health-report.py
@@ -58,7 +58,7 @@ def lambda_handler(event, context):
             Key="Health/{}.json".format(target_account.account_id),
         )
 
-    except AssumeRoleError as e:
+    except AntiopeAssumeRoleError as e:
         logger.error("Unable to assume role into account {}({})".format(target_account.account_name, target_account.account_id))
         return()
     except ClientError as e:

--- a/aws-inventory/lambda/inventory-health-report.py
+++ b/aws-inventory/lambda/inventory-health-report.py
@@ -62,10 +62,10 @@ def lambda_handler(event, context):
         logger.error("Unable to assume role into account {}({})".format(target_account.account_name, target_account.account_id))
         return()
     except ClientError as e:
-        logger.error("AWS Error getting info for {}: {}".format(target_account.account_name, e))
-        return()
+        logger.critical("AWS Error getting info for {}: {}".format(target_account.account_name, e))
+        raise
     except Exception as e:
-        logger.error("{}\nMessage: {}\nContext: {}".format(e, message, vars(context)))
+        logger.critical("{}\nMessage: {}\nContext: {}".format(e, message, vars(context)))
         raise
 
 

--- a/aws-inventory/lambda/inventory-iam.py
+++ b/aws-inventory/lambda/inventory-iam.py
@@ -35,7 +35,7 @@ def lambda_handler(event, context):
         discover_users(target_account)
         discover_saml_provider(target_account)
 
-    except AssumeRoleError as e:
+    except AntiopeAssumeRoleError as e:
         logger.error("Unable to assume role into account {}({})".format(target_account.account_name, target_account.account_id))
         return()
     except ClientError as e:

--- a/aws-inventory/lambda/inventory-iam.py
+++ b/aws-inventory/lambda/inventory-iam.py
@@ -39,10 +39,10 @@ def lambda_handler(event, context):
         logger.error("Unable to assume role into account {}({})".format(target_account.account_name, target_account.account_id))
         return()
     except ClientError as e:
-        logger.error("AWS Error getting info for {}: {}".format(target_account.account_name, e))
-        return()
+        logger.critical("AWS Error getting info for {}: {}".format(target_account.account_name, e))
+        raise
     except Exception as e:
-        logger.error("{}\nMessage: {}\nContext: {}".format(e, message, vars(context)))
+        logger.critical("{}\nMessage: {}\nContext: {}".format(e, message, vars(context)))
         raise
 
 def discover_roles(account):

--- a/aws-inventory/lambda/inventory-instances-sg.py
+++ b/aws-inventory/lambda/inventory-instances-sg.py
@@ -41,7 +41,7 @@ def lambda_handler(event, context):
             process_securitygroups(target_account, ec2_client, r)
 
 
-    except AssumeRoleError as e:
+    except AntiopeAssumeRoleError as e:
         logger.error("Unable to assume role into account {}({})".format(target_account.account_name, target_account.account_id))
         return()
     except ClientError as e:

--- a/aws-inventory/lambda/inventory-instances-sg.py
+++ b/aws-inventory/lambda/inventory-instances-sg.py
@@ -45,10 +45,10 @@ def lambda_handler(event, context):
         logger.error("Unable to assume role into account {}({})".format(target_account.account_name, target_account.account_id))
         return()
     except ClientError as e:
-        logger.error("AWS Error getting info for {}: {}".format(target_account.account_name, e))
-        return()
+        logger.critical("AWS Error getting info for {}: {}".format(target_account.account_name, e))
+        raise
     except Exception as e:
-        logger.error("{}\nMessage: {}\nContext: {}".format(e, message, vars(context)))
+        logger.critical("{}\nMessage: {}\nContext: {}".format(e, message, vars(context)))
         raise
 
 

--- a/aws-inventory/lambda/inventory-kms.py
+++ b/aws-inventory/lambda/inventory-kms.py
@@ -29,7 +29,7 @@ def lambda_handler(event, context):
         for r in target_account.get_regions():
             discover_keys(target_account, r)
 
-    except AssumeRoleError as e:
+    except AntiopeAssumeRoleError as e:
         logger.error("Unable to assume role into account {}({})".format(target_account.account_name, target_account.account_id))
         return()
     except ClientError as e:

--- a/aws-inventory/lambda/inventory-lambdas.py
+++ b/aws-inventory/lambda/inventory-lambdas.py
@@ -33,7 +33,7 @@ def lambda_handler(event, context):
             discover_lambdas(target_account, r)
             discover_lambda_layer(target_account, r)
 
-    except AssumeRoleError as e:
+    except AntiopeAssumeRoleError as e:
         logger.error("Unable to assume role into account {}({})".format(target_account.account_name, target_account.account_id))
         return()
     except ClientError as e:

--- a/aws-inventory/lambda/inventory-lambdas.py
+++ b/aws-inventory/lambda/inventory-lambdas.py
@@ -37,10 +37,10 @@ def lambda_handler(event, context):
         logger.error("Unable to assume role into account {}({})".format(target_account.account_name, target_account.account_id))
         return()
     except ClientError as e:
-        logger.error("AWS Error getting info for {}: {}".format(target_account.account_name, e))
-        return()
+        logger.critical("AWS Error getting info for {}: {}".format(target_account.account_name, e))
+        raise
     except Exception as e:
-        logger.error("{}\nMessage: {}\nContext: {}".format(e, message, vars(context)))
+        logger.critical("{}\nMessage: {}\nContext: {}".format(e, message, vars(context)))
         raise
 
 def discover_lambdas(target_account, region):

--- a/aws-inventory/lambda/inventory-route53.py
+++ b/aws-inventory/lambda/inventory-route53.py
@@ -30,7 +30,7 @@ def lambda_handler(event, context):
         discover_domains(target_account)
         discover_zones(target_account)
 
-    except AssumeRoleError as e:
+    except AntiopeAssumeRoleError as e:
         logger.error("Unable to assume role into account {}({})".format(target_account.account_name, target_account.account_id))
         return()
     except ClientError as e:

--- a/aws-inventory/lambda/inventory-route53.py
+++ b/aws-inventory/lambda/inventory-route53.py
@@ -34,10 +34,10 @@ def lambda_handler(event, context):
         logger.error("Unable to assume role into account {}({})".format(target_account.account_name, target_account.account_id))
         return()
     except ClientError as e:
-        logger.error("AWS Error getting info for {}: {}".format(target_account.account_name, e))
-        return()
+        logger.critical("AWS Error getting info for {}: {}".format(target_account.account_name, e))
+        raise
     except Exception as e:
-        logger.error("{}\nMessage: {}\nContext: {}".format(e, message, vars(context)))
+        logger.critical("{}\nMessage: {}\nContext: {}".format(e, message, vars(context)))
         raise
 
 def discover_domains(account):

--- a/aws-inventory/lambda/inventory-secrets.py
+++ b/aws-inventory/lambda/inventory-secrets.py
@@ -29,7 +29,7 @@ def lambda_handler(event, context):
         for r in target_account.get_regions():
             discover_secrets(target_account, r)
 
-    except AssumeRoleError as e:
+    except AntiopeAssumeRoleError as e:
         logger.error("Unable to assume role into account {}({})".format(target_account.account_name, target_account.account_id))
         return()
     except ClientError as e:

--- a/aws-inventory/lambda/inventory-ssm.py
+++ b/aws-inventory/lambda/inventory-ssm.py
@@ -40,10 +40,10 @@ def lambda_handler(event, context):
         logger.error("Unable to assume role into account {}({})".format(target_account.account_name, target_account.account_id))
         return()
     except ClientError as e:
-        logger.error("AWS Error getting info for {}: {}".format(target_account.account_name, e))
-        return()
+        logger.critical("AWS Error getting info for {}: {}".format(target_account.account_name, e))
+        raise
     except Exception as e:
-        logger.error("{}\nMessage: {}\nContext: {}".format(e, message, vars(context)))
+        logger.critical("{}\nMessage: {}\nContext: {}".format(e, message, vars(context)))
         raise
 
 

--- a/aws-inventory/lambda/inventory-ssm.py
+++ b/aws-inventory/lambda/inventory-ssm.py
@@ -36,7 +36,7 @@ def lambda_handler(event, context):
             process_instances(target_account, client, r)
 
 
-    except AssumeRoleError as e:
+    except AntiopeAssumeRoleError as e:
         logger.error("Unable to assume role into account {}({})".format(target_account.account_name, target_account.account_id))
         return()
     except ClientError as e:

--- a/aws-inventory/lambda/inventory-support-cases.py
+++ b/aws-inventory/lambda/inventory-support-cases.py
@@ -32,7 +32,7 @@ def lambda_handler(event, context):
         target_account = AWSAccount(message['account_id'])
         support_client = target_account.get_client('support', region="us-east-1") # Support API is in us-east-1 only
         cases = get_cases(target_account, support_client, get_all)
-    except AssumeRoleError as e:
+    except AntiopeAssumeRoleError as e:
         logger.error("Unable to assume role into account {}({})".format(target_account.account_name, target_account.account_id))
         return()
     except ClientError as e:

--- a/aws-inventory/lambda/inventory-trusted-advisor.py
+++ b/aws-inventory/lambda/inventory-trusted-advisor.py
@@ -45,10 +45,14 @@ def lambda_handler(event, context):
         logger.error("Unable to assume role into account {}({})".format(target_account.account_name, target_account.account_id))
         return()
     except ClientError as e:
-        logger.error("AWS Error getting info for {}: {}".format(target_account.account_name, e))
-        return()
+        if e.response['Error']['Code'] == "SubscriptionRequiredException":
+            logger.error("Premium support is not enabled in {}({})".format(target_account.account_name, target_account.account_id))
+            return()
+        else:
+            logger.critical("AWS Error getting info for {}: {}".format(target_account.account_name, e))
+            raise
     except Exception as e:
-        logger.error("{}\nMessage: {}\nContext: {}".format(e, message, vars(context)))
+        logger.critical("{}\nMessage: {}\nContext: {}".format(e, message, vars(context)))
         raise
 
 def get_checks(target_account, client):

--- a/aws-inventory/lambda/inventory-trusted-advisor.py
+++ b/aws-inventory/lambda/inventory-trusted-advisor.py
@@ -41,7 +41,7 @@ def lambda_handler(event, context):
         for c in checks:
             process_ta_check(target_account, support_client, c)
 
-    except AssumeRoleError as e:
+    except AntiopeAssumeRoleError as e:
         logger.error("Unable to assume role into account {}({})".format(target_account.account_name, target_account.account_id))
         return()
     except ClientError as e:

--- a/aws-inventory/lambda/inventory-vpc.py
+++ b/aws-inventory/lambda/inventory-vpc.py
@@ -33,10 +33,10 @@ def lambda_handler(event, context):
         logger.error("Unable to assume role into account {}({})".format(target_account.account_name, target_account.account_id))
         return()
     except ClientError as e:
-        logger.error("AWS Error getting info for {}: {}".format(target_account.account_name, e))
-        return()
+        logger.critical("AWS Error getting info for {}: {}".format(target_account.account_name, e))
+        raise
     except Exception as e:
-        logger.error("{}\nMessage: {}\nContext: {}".format(e, message, vars(context)))
+        logger.critical("{}\nMessage: {}\nContext: {}".format(e, message, vars(context)))
         raise
 
 def discover_vpcs(target_account, region):

--- a/aws-inventory/lambda/inventory-vpc.py
+++ b/aws-inventory/lambda/inventory-vpc.py
@@ -29,7 +29,7 @@ def lambda_handler(event, context):
         for r in target_account.get_regions():
             discover_vpcs(target_account, r)
 
-    except AssumeRoleError as e:
+    except AntiopeAssumeRoleError as e:
         logger.error("Unable to assume role into account {}({})".format(target_account.account_name, target_account.account_id))
         return()
     except ClientError as e:

--- a/aws-inventory/lambda/report-accounts.py
+++ b/aws-inventory/lambda/report-accounts.py
@@ -55,7 +55,10 @@ def handler(event, context):
             j['payer_name'] = "Not Found"
 
         # Build the cross account role link
-        j['assume_role_link'] = assume_role_link.format(a.account_id, os.environ['ROLE_NAME'], a.account_name, os.environ['ROLE_NAME'])
+        if hasattr(a, 'cross_account_role') and a.cross_account_role is not None:
+            j['assume_role_link'] = assume_role_link.format(a.account_id, os.environ['ROLE_NAME'], a.account_name, os.environ['ROLE_NAME'])
+        else:
+            j['assume_role_link'] = "No Cross Account Role"
         json_data['accounts'].append(j)
 
 

--- a/gcp-inventory/gcp_lib/project.py
+++ b/gcp-inventory/gcp_lib/project.py
@@ -122,9 +122,6 @@ class GCPProject(object):
             raise ProjectLookupError("Failed to get {} from {} in {}: {}".format(key, table_name, self, e))
 
 
-class AssumeRoleError(Exception):
-    '''raised when the AssumeRole Fails'''
-
 class ProjectUpdateError(Exception):
     '''raised when an update to DynamoDB Fails'''
 

--- a/lib/account.py
+++ b/lib/account.py
@@ -82,7 +82,7 @@ class AWSAccount(object):
         }
         Which can be passed to a new boto3 client or resource.
         Takes an optional session_name which can be used by CloudTrail and IAM
-        Raises AssumeRoleError() if the role is not found or cannot be assumed.
+        Raises AntiopeAssumeRoleError() if the role is not found or cannot be assumed.
         """
         client = boto3.client('sts')
 
@@ -94,7 +94,7 @@ class AWSAccount(object):
             self.creds = session['Credentials'] # Save for later
             return(session['Credentials'])
         except ClientError as e:
-            raise AssumeRoleError("Failed to assume role {} in account {} ({}): {}".format(self.cross_account_role_arn,
+            raise AntiopeAssumeRoleError("Failed to assume role {} in account {} ({}): {}".format(self.cross_account_role_arn,
                 self.account_name.encode('ascii', 'ignore'), self.account_id, e.response['Error']['Code']))
 
     def get_client(self, type, region=None, session_name=None):
@@ -211,7 +211,7 @@ class AWSAccount(object):
                 cfn_client      = self.get_client('cloudformation')
             else:
                 cfn_client      = self.get_client('cloudformation', region=region)
-        except AssumeRoleError:
+        except AntiopeAssumeRoleError:
             logger.error("Unable to assume role looking for {} in {}".format(PhysicalResourceId, self.account_id))
             return(None)
 
@@ -319,7 +319,7 @@ class AWSAccount(object):
             raise AccountLookupError("Failed to get {} from {} in account table: {}".format(key, self, e))
 
 
-class AssumeRoleError(Exception):
+class AntiopeAssumeRoleError(Exception):
     """raised when the AssumeRole Fails"""
 
 class AccountUpdateError(Exception):

--- a/lib/foreign_account.py
+++ b/lib/foreign_account.py
@@ -118,9 +118,6 @@ class ForeignAWSAccount(object):
             raise AccountLookupError("Failed to get {} from {} in account table: {}".format(key, self, e))
 
 
-class AssumeRoleError(Exception):
-    """raised when the AssumeRole Fails"""
-
 class AccountUpdateError(Exception):
     """raised when an update to DynamoDB Fails"""
 


### PR DESCRIPTION
All fatal exceptions log as critical (was error)
Generic ClientErrors trigger function failure, not a silent return()
Rename AssumeRoleError to AntiopeAssumeRoleError
New Account workflow returns proper json (not ddb json)
Better handling around errors for the following functions:
* kms keys
* secrets manager secrets
* Trusted advisor checks
Account table now tracks the cross-account-role-arn to use & aws reports indicate when the cross-account-role is missing
