### PR TITLE
Example of getting antiope to work on non-payer account

### DIFF
--- a/aws-inventory/lambda/pull_organization_data.py
+++ b/aws-inventory/lambda/pull_organization_data.py
@@ -107,13 +107,16 @@ def get_consolidated_billing_subaccounts(session_creds):
         aws_session_token = session_creds['SessionToken']
     )
     try:
+        roots = org_client.list_roots()
+        if not roots['Roots'][0]['Id']:
+            raise Exception('Roots not available')
 
         output = []
-        response = org_client.list_accounts(MaxResults=20)
+        response = org_client.list_accounts_for_parent(MaxResults=20, ParentId=roots['Roots'][0]['Id'])
         while 'NextToken' in response:
             output = output + response['Accounts']
             time.sleep(1)
-            response = org_client.list_accounts(MaxResults=20, NextToken=response['NextToken'])
+            response = org_client.list_accounts_for_parent(MaxResults=20, NextToken=response['NextToken'], ParentId=roots['Roots'][0]['Id'])
 
         output = output + response['Accounts']
         return(output)

--- a/aws-inventory/lambda/report-accounts.py
+++ b/aws-inventory/lambda/report-accounts.py
@@ -50,15 +50,7 @@ def handler(event, context):
         # We don't want to save the entire object's attributes.
         j = a.db_record.copy()
 
-        try:
-            if str(a.payer_id) in payers:
-                j['payer_name'] = payers[str(a.payer_id)]
-            else:
-                payer = AWSAccount(str(a.payer_id))
-                j['payer_name'] = payer.account_name
-                payers[payer.account_id] = payer.account_name
-        except AccountLookupError:
-            j['payer_name'] = "Not Found"
+        j['payer_name'] = 'Keanu'
 
         # Build the cross account role link
         if hasattr(a, 'cross_account_role') and a.cross_account_role is not None:


### PR DESCRIPTION
Bare minimum to get Antiope working on a non-payer account. This allows for inventory management to go through, at the expense of losing some data that requires AWS billing account access.

Every other setup step is followed, though the particular lambdas are modified for use on a non-payer account.