### PR TITLE
Manage Antiope Bucket via Cloudformation

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -7,7 +7,7 @@
 1. Make sure you have the AWS CLI installed
 1. Make sure you have a modern boto3
 1. Make sure you have jq installed.
-1. Create an S3 Bucket to act as the Antiope bucket
+1. Create an [S3 Bucket](docs/AntiopeBucket.md) to act as the Antiope bucket. A CloudFormation template exists to do this.
     * **It is important that the bucket be created in the region you intend to run Antiope.**
     * This bucket contains all the packaged code, discovered resources and Reports.
 1. You'll need cftdeploy python package & scripts:

--- a/cloudformation/antiope-bucket-ImportTemplate.yaml
+++ b/cloudformation/antiope-bucket-ImportTemplate.yaml
@@ -1,0 +1,23 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Create and Manage the Antiope S3 Bucket (and event notifications)
+
+Parameters:
+
+  pBucketName:
+    Description: Name of the Antiope Bucket to hold all the data
+    Type: String
+
+Resources:
+  AntiopeBucket:
+    Type: AWS::S3::Bucket
+    DeletionPolicy: Retain
+    # DependsOn: AntiopeBucketNotificationTopicPolicy
+    Properties:
+      AccessControl: Private
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+      BucketName: !Ref pBucketName
+
+

--- a/cloudformation/antiope-bucket-Template.yaml
+++ b/cloudformation/antiope-bucket-Template.yaml
@@ -7,6 +7,18 @@ Parameters:
     Description: Name of the Antiope Bucket to hold all the data
     Type: String
 
+  pImportState:
+    Description: Set this to True if you're going to try and import an existing bucket into S3 Management
+    Type: String
+    Default: False
+    AllowedValues:
+      - True
+      - False
+
+Conditions:
+  cNotImportState: !Equals [ !Ref pImportState, False]
+  cImportState: !Equals [ !Ref pImportState, True]
+
 Resources:
   AntiopeBucket:
     Type: AWS::S3::Bucket
@@ -24,17 +36,25 @@ Resources:
       # LoggingConfiguration: <- Probably unnecessary, but if someone needs it for compliance
       # MetricsConfigurations: <- Might be useful to see metrics on the primary keys of the bucket
       # InventoryConfiguration: <- Might be useful to pull out the Resources/ objects into a specific report
+
+
+
       NotificationConfiguration:
         TopicConfigurations:
-          - Event: 's3:ObjectCreated:*'
-            Filter:
-              S3Key:
-                Rules:
-                  - Name: prefix
-                    Value: "Resources/"
-                  - Name: suffix
-                    Value: ".json"
-            Topic: !Ref ResourceNotificationTopic
+          - Fn::If:
+            - cImportState
+            - Ref: AWS::NoValue
+            - Event: 's3:ObjectCreated:*'
+              Filter:
+                S3Key:
+                  Rules:
+                    - Name: prefix
+                      Value: "Resources/"
+                    - Name: suffix
+                      Value: ".json"
+              Topic: !Ref ResourceNotificationTopic
+
+
       OwnershipControls:
         Rules:
         - ObjectOwnership: BucketOwnerPreferred
@@ -44,11 +64,20 @@ Resources:
         IgnorePublicAcls: True
         RestrictPublicBuckets: False  # This rule also prohibits Cross-Account bucket access
 
+              # - Fn::If:
+              #   - cDeployCustomStack
+              #   - Ref: pDeployCustomStackStateMachineArn
+              #   - Ref: AWS::NoValue
+
+
+
+
   # TODO
   # What Bucket Policy is needed?
 
   ResourceNotificationTopic:
     Type: AWS::SNS::Topic
+    Condition: cNotImportState # Don't attempt to create if we're doing an import
     Properties:
       DisplayName: !Sub "Destination of PutObject calls from ${pBucketName}"
       TopicName: !Sub "${pBucketName}-Resources-PutObject"
@@ -56,6 +85,7 @@ Resources:
   # This Policy can be reused for any future Topics
   AntiopeBucketNotificationTopicPolicy:
     Type: AWS::SNS::TopicPolicy
+    Condition: cNotImportState # Don't attempt to create if we're doing an import
     Properties:
       Topics:
         - !Ref ResourceNotificationTopic
@@ -82,21 +112,25 @@ Resources:
 Outputs:
 
   Bucket:
-    Value: !Ref AntiopeBucket
+    Value: !Ref pBucketName
     Description: Antiope Bucket Name
 
   BucketArn:
+    Condition: cNotImportState # Import doesn't support stack outputs
     Value: !GetAtt AntiopeBucket.Arn
     Description: Antiope Bucket ARN
 
   BucketDomainName:
+    Condition: cNotImportState # Import doesn't support stack outputs
     Value: !GetAtt AntiopeBucket.DomainName
     Description: The IPv4 DNS name of the Antiope Bucket
 
   ResourceNotificationTopicArn:
+    Condition: cNotImportState # Import doesn't support stack outputs
     Value: !Ref ResourceNotificationTopic
     Description: ARN of the Topic where Resources PubObject events are Sent
 
   ResourceNotificationTopicName:
+    Condition: cNotImportState # Import doesn't support stack outputs
     Value: !GetAtt ResourceNotificationTopic.TopicName
     Description: Name of the Topic where Resources PubObject events are Sent

--- a/cloudformation/antiope-bucket-Template.yaml
+++ b/cloudformation/antiope-bucket-Template.yaml
@@ -1,0 +1,102 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Create and Manage the Antiope S3 Bucket (and event notifications)
+
+Parameters:
+
+  pBucketName:
+    Description: Name of the Antiope Bucket to hold all the data
+    Type: String
+
+Resources:
+  AntiopeBucket:
+    Type: AWS::S3::Bucket
+    DeletionPolicy: Retain
+    # DependsOn: AntiopeBucketNotificationTopicPolicy
+    Properties:
+      AccessControl: Private
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+      BucketName: !Ref pBucketName
+      # Additional Configuration options to come back and revisit.
+      # LifecycleConfiguration: <- I don't think we'd ever want to expire resources, but maybe over time?
+      # LoggingConfiguration: <- Probably unnecessary, but if someone needs it for compliance
+      # MetricsConfigurations: <- Might be useful to see metrics on the primary keys of the bucket
+      # InventoryConfiguration: <- Might be useful to pull out the Resources/ objects into a specific report
+      NotificationConfiguration:
+        TopicConfigurations:
+          - Event: 's3:ObjectCreated:*'
+            Filter:
+              S3Key:
+                Rules:
+                  - Name: prefix
+                    Value: "Resources/"
+                  - Name: suffix
+                    Value: ".json"
+            Topic: !Ref ResourceNotificationTopic
+      OwnershipControls:
+        Rules:
+        - ObjectOwnership: BucketOwnerPreferred
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: True
+        BlockPublicPolicy: True
+        IgnorePublicAcls: True
+        RestrictPublicBuckets: False  # This rule also prohibits Cross-Account bucket access
+
+  # TODO
+  # What Bucket Policy is needed?
+
+  ResourceNotificationTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      DisplayName: !Sub "Destination of PutObject calls from ${pBucketName}"
+      TopicName: !Sub "${pBucketName}-Resources-PutObject"
+
+  # This Policy can be reused for any future Topics
+  AntiopeBucketNotificationTopicPolicy:
+    Type: AWS::SNS::TopicPolicy
+    Properties:
+      Topics:
+        - !Ref ResourceNotificationTopic
+      PolicyDocument:
+        Version: '2012-10-17'
+        Id: AllowAntiopeBucket
+        Statement:
+        - Sid: AllowAntiopeBucketPublish
+          Effect: Allow
+          Principal:
+            AWS: "*"
+          Action:
+          - SNS:Publish
+          Resource:
+          - !Ref ResourceNotificationTopic
+          Condition:
+            ArnLike:
+              aws:SourceArn: !Sub "arn:aws:s3:*:*:${pBucketName}"
+            StringEquals:
+              aws:SourceAccount: !Ref AWS::AccountId
+
+
+
+Outputs:
+
+  Bucket:
+    Value: !Ref AntiopeBucket
+    Description: Antiope Bucket Name
+
+  BucketArn:
+    Value: !GetAtt AntiopeBucket.Arn
+    Description: Antiope Bucket ARN
+
+  BucketDomainName:
+    Value: !GetAtt AntiopeBucket.DomainName
+    Description: The IPv4 DNS name of the Antiope Bucket
+
+  ResourceNotificationTopicArn:
+    Value: !Ref ResourceNotificationTopic
+    Description: ARN of the Topic where Resources PubObject events are Sent
+
+  ResourceNotificationTopicName:
+    Value: !GetAtt ResourceNotificationTopic.TopicName
+    Description: Name of the Topic where Resources PubObject events are Sent

--- a/cloudformation/antiope-bucket-Template.yaml
+++ b/cloudformation/antiope-bucket-Template.yaml
@@ -7,23 +7,12 @@ Parameters:
     Description: Name of the Antiope Bucket to hold all the data
     Type: String
 
-  pImportState:
-    Description: Set this to True if you're going to try and import an existing bucket into S3 Management
-    Type: String
-    Default: False
-    AllowedValues:
-      - True
-      - False
-
-Conditions:
-  cNotImportState: !Equals [ !Ref pImportState, False]
-  cImportState: !Equals [ !Ref pImportState, True]
-
 Resources:
+
   AntiopeBucket:
     Type: AWS::S3::Bucket
     DeletionPolicy: Retain
-    # DependsOn: AntiopeBucketNotificationTopicPolicy
+    DependsOn: AntiopeBucketNotificationTopicPolicy
     Properties:
       AccessControl: Private
       BucketEncryption:
@@ -36,25 +25,17 @@ Resources:
       # LoggingConfiguration: <- Probably unnecessary, but if someone needs it for compliance
       # MetricsConfigurations: <- Might be useful to see metrics on the primary keys of the bucket
       # InventoryConfiguration: <- Might be useful to pull out the Resources/ objects into a specific report
-
-
-
       NotificationConfiguration:
         TopicConfigurations:
-          - Fn::If:
-            - cImportState
-            - Ref: AWS::NoValue
-            - Event: 's3:ObjectCreated:*'
-              Filter:
-                S3Key:
-                  Rules:
-                    - Name: prefix
-                      Value: "Resources/"
-                    - Name: suffix
-                      Value: ".json"
-              Topic: !Ref ResourceNotificationTopic
-
-
+          - Event: 's3:ObjectCreated:*'
+            Topic: !Ref ResourceNotificationTopic
+            Filter:
+              S3Key:
+                Rules:
+                  - Name: prefix
+                    Value: "Resources/"
+                  - Name: suffix
+                    Value: ".json"
       OwnershipControls:
         Rules:
         - ObjectOwnership: BucketOwnerPreferred
@@ -64,20 +45,11 @@ Resources:
         IgnorePublicAcls: True
         RestrictPublicBuckets: False  # This rule also prohibits Cross-Account bucket access
 
-              # - Fn::If:
-              #   - cDeployCustomStack
-              #   - Ref: pDeployCustomStackStateMachineArn
-              #   - Ref: AWS::NoValue
-
-
-
-
   # TODO
   # What Bucket Policy is needed?
 
   ResourceNotificationTopic:
     Type: AWS::SNS::Topic
-    Condition: cNotImportState # Don't attempt to create if we're doing an import
     Properties:
       DisplayName: !Sub "Destination of PutObject calls from ${pBucketName}"
       TopicName: !Sub "${pBucketName}-Resources-PutObject"
@@ -85,7 +57,6 @@ Resources:
   # This Policy can be reused for any future Topics
   AntiopeBucketNotificationTopicPolicy:
     Type: AWS::SNS::TopicPolicy
-    Condition: cNotImportState # Don't attempt to create if we're doing an import
     Properties:
       Topics:
         - !Ref ResourceNotificationTopic
@@ -107,8 +78,6 @@ Resources:
             StringEquals:
               aws:SourceAccount: !Ref AWS::AccountId
 
-
-
 Outputs:
 
   Bucket:
@@ -116,21 +85,17 @@ Outputs:
     Description: Antiope Bucket Name
 
   BucketArn:
-    Condition: cNotImportState # Import doesn't support stack outputs
     Value: !GetAtt AntiopeBucket.Arn
     Description: Antiope Bucket ARN
 
   BucketDomainName:
-    Condition: cNotImportState # Import doesn't support stack outputs
     Value: !GetAtt AntiopeBucket.DomainName
     Description: The IPv4 DNS name of the Antiope Bucket
 
   ResourceNotificationTopicArn:
-    Condition: cNotImportState # Import doesn't support stack outputs
     Value: !Ref ResourceNotificationTopic
-    Description: ARN of the Topic where Resources PubObject events are Sent
+    Description: ARN of the Topic where Resources PutObject events are Sent
 
   ResourceNotificationTopicName:
-    Condition: cNotImportState # Import doesn't support stack outputs
     Value: !GetAtt ResourceNotificationTopic.TopicName
-    Description: Name of the Topic where Resources PubObject events are Sent
+    Description: Name of the Topic where Resources PutObject events are Sent

--- a/docs/AntiopeBucket.md
+++ b/docs/AntiopeBucket.md
@@ -1,0 +1,54 @@
+# Managing the Antiope Bucket
+
+
+## Creating a New Antiope Bucket
+
+To create a fresh antiope bucket, leverage the CFT in [cloudformation/antiope-bucket-Template.yaml](../cloudformation/antiope-bucket-Template.yaml).
+
+Steps to deploy:
+1. Generate a manifest:
+```bash
+cft-generate-manifest -m config-files/antiope-bucket-Manifest.yaml -t cloudformation/antiope-bucket-Template.yaml
+```
+2. Edit the `config-files/antiope-bucket-Manifest.yaml` and set the stackname and pBucketName
+3. Deploy the CloudFormation Stack with:
+```bash
+cft-deploy -m config-files/antiope-bucket-Manifest.yaml
+```
+
+Now you can proceed to deploy the rest of Antiope
+
+## Importing an existing Antiope Bucket into Cloudformation
+
+If for whatever reason, you have an existing Antiope bucket you wish to use, you can use CloudFormation import to import the existing Antiope Bucket into CloudFormation, then update the bucket stack to include the other resources.
+
+CloudFormation import has some significant limitations. Not all resources _can_ be imported, and all resources in a template _must_ be imported. To work around these limitations, there is a barebones CFT that can be used to import the existing bucket into CloudFormation. Once imported, the stack can be updated to use the main template. The steps to import an existing bucket are as follows:
+
+1. Create an import change set:
+```bash
+aws cloudformation create-change-set --output text \
+	--stack-name antiope-bucket \
+	--change-set-name bucket-import \
+	--parameters ParameterKey=pBucketName,ParameterValue=REPLACE_WITH_YOUR_BUCKET_NAME \
+	--template-body file://cloudformation/antiope-bucket-ImportTemplate.yaml \
+	--change-set-type IMPORT \
+	--resources-to-import ResourceType=AWS::S3::Bucket,LogicalResourceId=AntiopeBucket,ResourceIdentifier={BucketName=REPLACE_WITH_YOUR_BUCKET_NAME}
+```
+2. Review the change set
+```bash
+aws cloudformation describe-change-set --change-set-name bucket-import --stack-name antiope-bucket
+```
+3. Execute the change set
+```bash
+aws cloudformation execute-change-set --change-set-name bucket-import --stack-name antiope-bucket
+```
+4. Validate the new stack is in `IMPORT_COMPLETE` state
+5. Now update the new stack with the full-featured template. First Generate a manifest:
+```bash
+cft-generate-manifest -m config-files/antiope-bucket-Manifest.yaml -t cloudformation/antiope-bucket-Template.yaml
+```
+6. Edit the `config-files/antiope-bucket-Manifest.yaml` and set the stackname and pBucketName to the values used for the import
+7. Deploy the CloudFormation Stack with:
+```bash
+cft-deploy -m config-files/antiope-bucket-Manifest.yaml --force
+```


### PR DESCRIPTION
This PR include two templates, one allows for the importation of an existing Antiope Bucket into Cloudformation. The Second template can be used to either deploy a fresh Antiope Bucket, or (if applied to an imported bucket) will configure the Antiope Bucket with S3 Event Notifications  to SNS so multiple consumers can exist on the same Event Notification configuration. 